### PR TITLE
Fix `[compat]` entries in `Project.toml`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SimpleGraphs = "55797a34-41de-5266-9ec1-32ac4eb504d3"
 [compat]
 julia = "1"
 Plots = "1"
-SimpleDrawing = "0"
+SimpleDrawing = "0.0.1, 0.1, 0.2"
 SimpleGraphs = "0.6"
 
 [extras]


### PR DESCRIPTION
In the General registry, we now **strongly** discourage users from having `[compat]` entries of the form:
```toml
SomePackage = "0"
```

These `[compat]` entries are problematic because they include an infinite number of breaking releases.

This pull request fixes the `[compat]` entries in the `Project.toml` file for this package.

cc: @scheinerman